### PR TITLE
added pith pixel position as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,19 @@ python main.py inference checkpoints/INBD_EH/model.pt.zip dataset/EH/inputimages
 python main.py inference checkpoints/INBD_EH/model.pt.zip dataset/EH/test_inputimages.txt
 ```
 
-***
+### adding pith pixel position as argument
+In Pinus taeda L. species, U-Net model do not segment the pith pixel correctly. In such species, pith can be model
+as a single pixel ([see paper](https://arxiv.org/abs/2404.01952)). 
+```bash
 
+#single imagefile
+python main.py inference checkpoints/UruDendro/model.pt.zip dataset/UruDendro4_1504/T0_B1_N32_A.png --cy 766 --cx 709
+```
+Where `--cy` and `--cx` are the y and x coordinates of the pith pixel in the image. Model checkpoints/UruDendro/model.pt.zip
+was trained on the UruDendro dataset, which is a dataset of Pinus taeda L. tree rings ([see dataset](https://doi.org/10.5281/zenodo.15110646)).
+Image `dataset/UruDendro4_1504/T0_B1_N32_A.png` is an example image from the UruDendro4 dataset ([see dataset](https://doi.org/10.5281/zenodo.15653340)).
+resized to 1504x1504 pixels. Image can be downloaded from [link](https://finguy-my.sharepoint.com/:i:/g/personal/henry_marichal_fing_edu_uy/Efpex2iHvplKt3c1NDdK7CUBYCiF-5VOi8N3XV51rEPQiw?e=rF9trA).
+***
 
 ## Training:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ Where `--cy` and `--cx` are the y and x coordinates of the pith pixel in the ima
 was trained on the UruDendro dataset, which is a dataset of Pinus taeda L. tree rings ([see dataset](https://doi.org/10.5281/zenodo.15110646)).
 Image `dataset/UruDendro4_1504/T0_B1_N32_A.png` is an example image from the UruDendro4 dataset ([see dataset](https://doi.org/10.5281/zenodo.15653340)).
 resized to 1504x1504 pixels. Image can be downloaded from [link](https://finguy-my.sharepoint.com/:i:/g/personal/henry_marichal_fing_edu_uy/Efpex2iHvplKt3c1NDdK7CUBYCiF-5VOi8N3XV51rEPQiw?e=rF9trA).
+
+To run in a list of files, the input file should contain the image paths and the pith pixel coordinates.
+
+```bash
+#list of imagefiles
+python main.py inference checkpoints/UruDendro/model.pt.zip dataset/UruDendro4_1504/test_inputimages.csv
+```
+
+Where `test_inputimages.csv` is a CSV file with the following format:
+``` 
+Code, cx, cy
+T0_B1_N32_A.png, 709, 766
+```
+
+
 ***
 
 ## Training:

--- a/main.py
+++ b/main.py
@@ -145,7 +145,9 @@ def inference(args):
         upscale = (not args.seg)
         if args.images.lower().endswith('.csv'):
             #use cx, cy from csv file
-            pith_pixel_position = (cy_list[i], cx_list[i])
+            cy = cy_list[i]
+            cx = cx_list[i]
+            pith_pixel_position = (cy,cx)
 
         try:
 
@@ -164,6 +166,16 @@ def inference(args):
             PIL.Image.fromarray((labelmap_rgba*255).astype('uint8')).save(outf+'.labelmap.png')
 
             open(outf+'.areas.csv', 'w').write(util.labelmap_to_areas_output(labelmap))
+
+            #to LabelMe format
+            from src.util import labelmap_to_contours, write_json, polygon_2_labelme_json
+
+            contours = labelmap_to_contours(labelmap, cy=cy,cx=cx)
+            if len(contours) == 0:
+                continue
+
+            labelme_json = polygon_2_labelme_json(contours, f)
+            write_json(labelme_json, outf+'.labelmap.json')
 
         if hasattr(output, 'boundaries'):
             from src import INBD

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ coverage==6.5.0
 Shapely==1.7.0
 opencv-contrib-python-headless==4.8.1.78
 opencv-python==4.8.1.78
+pandas==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ pytest==7.1.3
 mypy==0.982
 pytest-mypy==0.10.0
 coverage==6.5.0
+Shapely==1.7.0
+opencv-contrib-python-headless==4.8.1.78
+opencv-python==4.8.1.78


### PR DESCRIPTION
In Pinus taeda L. species, U-Net model do not segment the pith pixel correctly. In such species, pith can be model
as a single pixel ([see paper](https://arxiv.org/abs/2404.01952)). 
```bash

#single imagefile
python main.py inference checkpoints/UruDendro/model.pt.zip dataset/UruDendro4_1504/T0_B1_N32_A.png --cy 766 --cx 709
```
Where `--cy` and `--cx` are the y and x coordinates of the pith pixel in the image. Model checkpoints/UruDendro/model.pt.zip
was trained on the UruDendro dataset, which is a dataset of Pinus taeda L. tree rings ([see dataset](https://doi.org/10.5281/zenodo.15110646)). Model can be downloaded from [here](https://finguy-my.sharepoint.com/:u:/g/personal/henry_marichal_fing_edu_uy/EWDFNHeQuNJNmtwpWh3dPpgBa62TBYvu55UbaNdmZiN6Jw?e=qv9gqQ).
Image `dataset/UruDendro4_1504/T0_B1_N32_A.png` is an example image from the UruDendro4 dataset ([see dataset](https://doi.org/10.5281/zenodo.15653340)).
resized to 1504x1504 pixels. Image can be downloaded from [link](https://finguy-my.sharepoint.com/:i:/g/personal/henry_marichal_fing_edu_uy/Efpex2iHvplKt3c1NDdK7CUBYCiF-5VOi8N3XV51rEPQiw?e=rF9trA).

Additionally, [LabelMe](https://github.com/wkentaro/labelme) output format is added. This allow to manually correct the ring predictions using the interactive tool. 