### PR TITLE
Image Input Control Check

### DIFF
--- a/src/datasets.py
+++ b/src/datasets.py
@@ -45,6 +45,8 @@ class Dataset:
             assert len(tgt_full.shape) == 3
 
             patch_size = int(self.patch_size  * max(self.scales))
+            min_dim = np.minimum(img_full.shape[1], img_full.shape[2])
+            patch_size = min(patch_size, min_dim)
             slack      =          patch_size // 2
             base       = os.path.basename(imagefile)
             for i,patch in enumerate(slice_into_patches_with_overlap(img_full, patch_size, slack)):
@@ -96,6 +98,7 @@ class Dataset:
     def create_dataloader(self, batch_size, shuffle=False, num_workers='auto'):
         if num_workers == 'auto':
             num_workers = os.cpu_count()
+        print(num_workers)
         return torch.utils.data.DataLoader(self, batch_size, shuffle, collate_fn=getattr(self, 'collate_fn', None),
                                            num_workers=num_workers, pin_memory=True,
                                            worker_init_fn=lambda x: np.random.seed(torch.randint(0,1000,(1,))[0].item()+x) )

--- a/src/datasets.py
+++ b/src/datasets.py
@@ -98,7 +98,6 @@ class Dataset:
     def create_dataloader(self, batch_size, shuffle=False, num_workers='auto'):
         if num_workers == 'auto':
             num_workers = os.cpu_count()
-        print(num_workers)
         return torch.utils.data.DataLoader(self, batch_size, shuffle, collate_fn=getattr(self, 'collate_fn', None),
                                            num_workers=num_workers, pin_memory=True,
                                            worker_init_fn=lambda x: np.random.seed(torch.randint(0,1000,(1,))[0].item()+x) )

--- a/src/models.py
+++ b/src/models.py
@@ -50,7 +50,7 @@ class UNet(torch.nn.Module):
         device = list(self.parameters())[0].device
         x      = x.to(device)
         # Check input size
-        if False and (x.shape[-2] < 5 or x.shape[-1] < 5):
+        if (x.shape[-2] < 5 or x.shape[-1] < 5):
             return torch.zeros((x.shape[0], self.cls.out_channels, x.shape[-2], x.shape[-1]), device=device)
 
         X = self.backbone(x)

--- a/src/models.py
+++ b/src/models.py
@@ -50,7 +50,7 @@ class UNet(torch.nn.Module):
         device = list(self.parameters())[0].device
         x      = x.to(device)
         # Check input size
-        if x.shape[-2] < 5 or x.shape[-1] < 5:
+        if False and (x.shape[-2] < 5 or x.shape[-1] < 5):
             return torch.zeros((x.shape[0], self.cls.out_channels, x.shape[-2], x.shape[-1]), device=device)
 
         X = self.backbone(x)

--- a/src/models.py
+++ b/src/models.py
@@ -49,7 +49,10 @@ class UNet(torch.nn.Module):
     def forward(self, x:torch.Tensor, sigmoid=False, return_features=False) -> torch.Tensor:
         device = list(self.parameters())[0].device
         x      = x.to(device)
-        
+        # Check input size
+        if x.shape[-2] < 5 or x.shape[-1] < 5:
+            return torch.zeros((x.shape[0], self.cls.out_channels, x.shape[-2], x.shape[-1]), device=device)
+
         X = self.backbone(x)
         X = ([x] + [X[f'out{i}'] for i in range(5)])[::-1]
         x = X.pop(0)


### PR DESCRIPTION
- Fix training error when the input image resolution is too small. In this situation, the center boundary is too small, and the forward pass in the UNET fails with the following error:

`boundary shape Calculated padded input size per channel: (12 x 3). Kernel size: (5 x 5). Kernel size can't be greater than the actual input size
`

- When generating dataset, patch size need to be smaller than input image. Added control check


Image Dataset from: https://doi.org/10.5281/zenodo.15110647
